### PR TITLE
render spaces, fill+stroke at once, return size

### DIFF
--- a/src/jsTifier.js
+++ b/src/jsTifier.js
@@ -4,11 +4,11 @@
 // Library: mllib.js
 // Desciption: Extends the CanvasRenderingContext2D that adds two functions: mlFillText and mlStrokeText.
 //
-// The prototypes are: 
+// The prototypes are:
 //
 // function mlFillText(text,x,y,w,h,vAlign,hAlign,lineheight);
 // function mlStrokeText(text,x,y,w,h,vAlign,hAlign,lineheight);
-// 
+//
 // Where vAlign can be: "top", "center" or "button"
 // And hAlign can be: "left", "center", "right" or "justify"
 // Author: Jordi Baylina. (baylina at uniclau.com)
@@ -16,9 +16,15 @@
 // Date: 2013-02-21
 
 function mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, fn) {
-    text = text.replace(/[\n]/g, " \n ");
-    text = text.replace(/\r/g, "");
-    var words = text.split(/[ ]+/);
+    text = text.replace(/\r/g, '');
+    var words = [];
+    var inLines = text.split('\n');
+    var i;
+    for (i=0; i < inLines.length; i++)
+    {
+    	if (i) words.push('\n');
+    	words = words.concat( inLines[i].split(' ') );
+    }
     var sp = this.measureText(' ').width;
     var lines = [];
     var actualline = 0;
@@ -29,6 +35,7 @@ function mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, fn) {
     i = 0;
     while (i < words.length) {
         var word = words[i];
+        if (word === '') word = " ";
         if (word == "\n") {
             lines[actualline].EndParagraph = true;
             actualline++;
@@ -44,7 +51,8 @@ function mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, fn) {
                     word = word.slice(0, word.length - 1);
                     wo.l = this.measureText(word).width;
                 }
-                if (word === "") return; // I can't fill a single character
+                if (word === "") word = " ";
+
                 wo.word = word;
                 lines[actualline].Words.push(wo);
                 actualsize = wo.l;
@@ -90,10 +98,16 @@ function mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, fn) {
     var oldTextAlign = this.textAlign;
     this.textAlign = "left";
 
+	var maxWidth = 0;
     for (var li in lines) {
+    	if (!lines.hasOwnProperty(li)) continue;
         var totallen = 0;
         var xx, usp;
-        for (wo in lines[li].Words) totallen += lines[li].Words[wo].l;
+        for (wo in lines[li].Words) {
+	    	if (!lines[li].Words.hasOwnProperty(wo)) continue;
+        	totallen += lines[li].Words[wo].l;
+        }
+        maxWidth = Math.max(maxWidth, totallen + sp * (lines[li].Words.length - 1));
         if (hAlign == "center") {
             usp = sp;
             xx = x + w / 2 - (totallen + sp * (lines[li].Words.length - 1)) / 2;
@@ -108,27 +122,38 @@ function mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, fn) {
             usp = sp;
         }
         for (wo in lines[li].Words) {
-            if (fn == "fillText") {
-                this.fillText(lines[li].Words[wo].word, xx, yy);
-            } else if (fn == "strokeText") {
+	    	if (!lines[li].Words.hasOwnProperty(wo)) continue;
+            if (fn == "strokeText" || fn=="fillStrokeText") {
                 this.strokeText(lines[li].Words[wo].word, xx, yy);
+            }
+            if (fn == "fillText" || fn=="fillStrokeText") {
+                this.fillText(lines[li].Words[wo].word, xx, yy);
             }
             xx += lines[li].Words[wo].l + usp;
         }
         yy += lineheight;
     }
     this.textAlign = oldTextAlign;
+
+    return {
+    	width: maxWidth,
+    	height: totalH,
+    };
 }
 
 (function mlInit() {
     CanvasRenderingContext2D.prototype.mlFunction = mlFunction;
 
     CanvasRenderingContext2D.prototype.mlFillText = function (text, x, y, w, h, vAlign, hAlign, lineheight) {
-        this.mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, "fillText");
+        return this.mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, "fillText");
     };
 
     CanvasRenderingContext2D.prototype.mlStrokeText = function (text, x, y, w, h, vAlign, hAlign, lineheight) {
-        this.mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, "strokeText");
+        return this.mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, "strokeText");
     };
-})();
 
+    CanvasRenderingContext2D.prototype.mlFillStrokeText = function (text, x, y, w, h, vAlign, hAlign, lineheight) {
+        return this.mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, "fillStrokeText");
+    };
+
+})();


### PR DESCRIPTION
Changes:
- render space characters
- fillStrokeText to do both at once as optimization
- return width and height of rendered text

I've made those changes to satisfy my needs. I'm not sure if you will like all of them, so go ahead and add what you like.
