### PR TITLE
Fix reference if the last line is empty

### DIFF
--- a/src/jsTifier.js
+++ b/src/jsTifier.js
@@ -89,10 +89,13 @@ function mlFunction(text, x, y, w, h, hAlign, vAlign, lineheight, fn) {
             }
         }
     }
-    if (actualsize === 0) lines.pop(); // We remove the last line if we have not added any thing here.
-
-    // The last line will be allways the last line of a paragraph even if it does not end with a  /n
-    lines[actualline].EndParagraph = true;
+    if (actualsize === 0) {
+        // We remove the last line if we have not added any thing here.
+        lines.pop();
+    } else {
+        // The last line will be allways the last line of a paragraph even if it does not end with a  /n
+        lines[actualline].EndParagraph = true;
+    }
 
 
     // Now we remove any line that does not fit in the heigth.


### PR DESCRIPTION
The pop caused an undefined on the EndParagraph = true statement.
